### PR TITLE
Set TERM if not set

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,6 +4,10 @@
 
 set -e
 
+if [ -z "$TERM" ]; then
+    export TERM="ansi"
+fi
+
 valid_domain="hooloovoo.rs"
 organization="hooloovoodoo"
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -4,6 +4,10 @@
 
 set -e
 
+if [ -z "$TERM" ]; then
+    export TERM="ansi"
+fi
+
 organization="hooloovoodoo"
 valid_prefixes=("feature" "bugfix" "release")
 

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -4,6 +4,10 @@
 
 set -e
 
+if [ -z "$TERM" ]; then
+    export TERM="ansi"
+fi
+
 # regex pattern for jira ticket (e.g., FLC-22)
 JIRA_TICKET_AUTOMATION_REGEX='^[A-Z]{3,4}-[0-9]+ #comment'
 


### PR DESCRIPTION
@ushtipak - check it out. Need this because InteliJ IDEA message issue:
```
$ git -c credential.helper= -c core.quotepath=false -c log.showSignature=false commit -F /private/var/folders/j8/p6_kvfl526x18jsxrmgh4q000000gp/T/git-commit-msg-.txt --
tput: No value for $TERM and no -T specified
```
