### PR TITLE
Fix set TERM if not set

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ -z "$TERM" ]; then
+if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
     export TERM="ansi"
 fi
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ -z "$TERM" ]; then
+if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
     export TERM="ansi"
 fi
 

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ -z "$TERM" ]; then
+if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
     export TERM="ansi"
 fi
 


### PR DESCRIPTION
InteliJ imbecils. `TERM = dumb.` 🤯 💥 🤯 

Fix:
```
if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
    export TERM="ansi"
fi
```

@ushtipak - please review and if all good, merge and release. Thanks 💚 