### PR TITLE
LET-3072: Add archive branch type; exempt falcon-docs from commit-msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ release. Re-run any time to update.
 | Hook | Enforces (org repos only) |
 |---|---|
 | `pre-commit`  | commit email is `*@hooloovoo.rs`; **blocks committing secrets** (`.env`, `.pgpass`, `.s3cfg`, `ops.env`, `*.pem`/`*.key`, ssh/aws keys, private-key/AWS-key content) |
-| `commit-msg`  | subject is `<TICKET> #comment <msg>` (e.g. `LET-2949 #comment …`); `Merge`/`Revert`/`fixup!`/`squash!` exempt |
-| `pre-push`    | branch starts with `feature/ bugfix/ release/ hotfix/ docs/ chore/` |
+| `commit-msg`  | subject is `<TICKET> #comment <msg>` (e.g. `LET-2949 #comment …`); `Merge`/`Revert`/`fixup!`/`squash!` exempt; the `falcon-docs` repo is exempt entirely |
+| `pre-push`    | branch starts with `feature/ bugfix/ release/ hotfix/ docs/ chore/ archive/` |
+
+`archive/` parks work that's worth keeping but not active (kept out of the
+stale-branch sweep). Convention: `archive/<jira>-<branch-name>`
+(e.g. `archive/LET-3072-pricing-plans-poc`) so the Jira carries the context —
+the hook checks only the prefix, the rest is convention.
 
 The secret denylist is intentionally kept in sync with the Falcon Claude Code
 guards (`falcon-cc-suite` `guard-files.sh` / `guard-bash.sh`) so the agent and

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -10,6 +10,11 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "$DIR/lib.sh"
 
+# falcon-docs is a docs-only repo — exempt from the ticket/#comment convention.
+if is_org_repo && [ "$(remote_repo)" = "falcon-docs" ]; then
+  exit 0
+fi
+
 # First non-empty, non-comment line is the subject.
 subject=$(grep -vE '^[[:space:]]*#' "$1" | grep -vE '^[[:space:]]*$' | head -n1)
 

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -28,5 +28,15 @@ remote_owner() {
   fi
 }
 
+# remote_repo: print the repo segment of origin's URL (last path part, sans .git),
+# empty if no remote. Works for git@, ssh:// and https:// forms.
+remote_repo() {
+  local url
+  url=$(git config --get remote.origin.url 2>/dev/null) || return 0
+  [ -z "$url" ] && return 0
+  url=${url%.git}
+  printf '%s' "${url##*/}"
+}
+
 # is_org_repo: 0 if origin owner == ORG, else 1. Repos outside the org pass through.
 is_org_repo() { [ "$(remote_owner)" = "$ORG" ]; }

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -11,7 +11,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 is_org_repo || exit 0
 
-VALID_PREFIXES=(feature bugfix release hotfix docs chore)
+VALID_PREFIXES=(feature bugfix release hotfix docs chore archive)
 ZERO="0000000000000000000000000000000000000000"
 
 bad=""


### PR DESCRIPTION
Per [LET-3072](https://hooloovoo.atlassian.net/browse/LET-3072) — Marko's suggestion to introduce an `archive/` branch convention, plus relaxing the commit-msg rule for the docs repo.

## Changes
- **`pre-push`** — add `archive` to the approved prefixes. Parks work that's worth keeping but not active (kept out of the stale-branch sweep). Convention: `archive/<jira>-<branch-name>` (e.g. `archive/LET-3072-pricing-plans-poc`). The hook checks only the prefix, same as the other types.
- **`commit-msg`** — exempt the `falcon-docs` repo (origin `hooloovoodoo/falcon-docs`) from the `<TICKET> #comment` requirement. It's a docs repo; no need to be strict on git. Other repos are unchanged.
- **`lib.sh`** — add `remote_repo()` helper (mirrors `remote_owner()`; handles git@/ssh/https URL forms).
- **`README.md`** — document both.

## Verification
- `bash -n` clean on all three scripts.
- End-to-end against the real hooks (5/5):
  - falcon-docs accepts a non-ticket commit message; falcon-backend still rejects it but accepts a ticketed one.
  - `archive/…` branch accepted on push; unprefixed branch still rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)