### PR TITLE
LET-3080: server-side policy gate (CI mirror of the hooks)

### DIFF
--- a/.github/workflows/policy-gate-self.yml
+++ b/.github/workflows/policy-gate-self.yml
@@ -1,0 +1,15 @@
+# Caller workflow — run the policy gate on PRs against git-hooks itself.
+# Canonical example of a consumer caller; a consumer repo's version is identical
+# except `uses:` points at hooloovoodoo/git-hooks/...@master instead of ./ .
+# Keep the job id `policy-gate` so the required check is "policy-gate / check"
+# in every repo.
+
+name: Policy gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  policy-gate:
+    uses: ./.github/workflows/policy-gate.yml

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -1,0 +1,150 @@
+# Reusable workflow — server-side policy gate (LET-3080).
+#
+# The authoritative, non-bypassable mirror of the client-side hooks in THIS repo
+# (hooks/commit-msg, hooks/pre-push, hooks/pre-commit). Local hooks are
+# bypassable (--no-verify) and only run if installed; this gate re-checks the
+# same rules on every PR so branch protection can block a violating merge.
+#
+# These rules MUST stay in sync with hooks/. Same repo on purpose: when you
+# change a rule in hooks/, change it here in the same PR.
+#
+# Each repo's caller workflow invokes this via:
+#   uses: hooloovoodoo/git-hooks/.github/workflows/policy-gate.yml@master
+# git-hooks is public, so any org repo (private or public) can call it with no
+# extra Actions access config. No secrets needed — contents:read is enough.
+
+name: Policy gate (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: policy-gate-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout caller repo (full history for base..head)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Policy checks (commit-msg / branch-name / secret denylist)
+        env:
+          RANGE_BASE: ${{ github.event.pull_request.base.sha }}
+          RANGE_HEAD: ${{ github.event.pull_request.head.sha }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        shell: bash
+        run: |
+          set +e            # we manage exit codes ourselves and report ALL violations
+          set -uo pipefail
+
+          fail=0
+          note() { printf '%s\n' "$*"; }
+          err()  { printf '::error::%s\n' "$*"; fail=1; }
+
+          # --- 1. branch name (mirror hooks/pre-push VALID_PREFIXES) --------
+          check_branch() {
+            local b="${1:-}" p ok=""
+            if [ -z "$b" ]; then note "branch: (none) — skipped"; return; fi
+            for p in feature bugfix release hotfix docs chore archive; do
+              case "$b" in "$p"/*|"$p") ok=1; break ;; esac
+            done
+            if [ -n "$ok" ]; then
+              note "✓ branch '$b' has an approved prefix"
+            else
+              err "branch '$b' needs an approved prefix: feature/ bugfix/ release/ hotfix/ docs/ chore/ archive/"
+            fi
+          }
+
+          # --- 2. commit subjects (mirror hooks/commit-msg) -----------------
+          # falcon-doc(s) is the docs-only repo, exempt from the ticket rule —
+          # same as hooks/commit-msg. Both spellings are listed because the live
+          # repo is "falcon-doc" (the hook's "falcon-docs" never matched it).
+          check_commits() {
+            local exempt_repo="${1:-}"
+            case "$exempt_repo" in
+              falcon-doc|falcon-docs) note "commit-msg: '$exempt_repo' is docs-exempt — skipped"; return ;;
+            esac
+            local allow='^(Merge|Revert|fixup!|squash!)'
+            local ticket='^[A-Z]{3,4}-[0-9]+ #comment'
+            local bad=0 s seen=0
+            while IFS= read -r s; do
+              [ -z "$s" ] && continue
+              seen=1
+              if [[ "$s" =~ $allow ]] || [[ "$s" =~ $ticket ]]; then
+                :
+              else
+                err "commit subject must be '<TICKET> #comment <msg>': ${s}"
+                bad=1
+              fi
+            done
+            if [ "$seen" = 0 ]; then note "commit-msg: no non-merge commits in range — skipped"
+            elif [ "$bad" = 0 ]; then note "✓ all commit subjects match '<TICKET> #comment <msg>'"; fi
+          }
+
+          # --- 3a. secret/credential FILES (mirror hooks/pre-commit) --------
+          check_secret_files() {
+            local f base bad=0 seen=0
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              seen=1
+              base=$(basename "$f")
+              case "$base" in
+                .pgpass|.s3cfg|.pg_service.conf|ops.env|.netrc|credentials|id_rsa|id_dsa|id_ecdsa|id_ed25519)
+                  err "secret/credential file: $f"; bad=1; continue ;;
+              esac
+              # .env in any form (.env, .env.<x>, <name>.env) but allow example/sample/template/dist
+              if printf '%s' "$base" | grep -Eq '(\.env$|^\.env\.)' \
+                 && ! printf '%s' "$base" | grep -Eq '\.(example|sample|template|dist)$'; then
+                err ".env / secrets file: $f"; bad=1; continue
+              fi
+              case "$f" in
+                *.pem|*.key|*/.aws/*|*/.ssh/*|*/.gnupg/*|*/.config/falcon/ops.env)
+                  err "key/secret path: $f"; bad=1; continue ;;
+              esac
+            done
+            if [ "$seen" = 0 ]; then note "secret-files: no files in diff — skipped"
+            elif [ "$bad" = 0 ]; then note "✓ no denylisted secret/credential files in the diff"; fi
+          }
+
+          # --- 3b. secret-like CONTENT in added lines (mirror hooks/pre-commit) ---
+          check_secret_content() {
+            local hits
+            hits=$(grep -E '^\+' | grep -Eo '(BEGIN [A-Z ]*PRIVATE KEY|AKIA[0-9A-Z]{16})' | sort -u || true)
+            if [ -n "$hits" ]; then
+              err "secret-like content in the added lines:"
+              printf '%s\n' "$hits" | sed 's/^/    /'
+            else
+              note "✓ no secret-like content (private keys / AWS keys) in added lines"
+            fi
+          }
+
+          # --- runner -------------------------------------------------------
+          # Process substitution (not pipes) so err() mutates $fail in this shell.
+          base="${RANGE_BASE:?missing base sha — caller must trigger on pull_request}"
+          head="${RANGE_HEAD:?missing head sha — caller must trigger on pull_request}"
+          mb=$(git merge-base "$base" "$head" 2>/dev/null || echo "$base")
+          note "== policy gate =="
+          note "range: ${mb}..${head}  branch: ${HEAD_BRANCH:-?}  repo: ${REPO_NAME:-?}"
+          note ""
+          check_branch        "${HEAD_BRANCH:-}"
+          check_commits       "${REPO_NAME:-}" < <(git log --no-merges --format=%s "${mb}..${head}")
+          check_secret_files                   < <(git diff --name-only --diff-filter=ACMR "${mb}..${head}")
+          check_secret_content                 < <(git diff --no-color "${mb}..${head}")
+          note ""
+          if [ "$fail" != 0 ]; then
+            note "✗ policy gate failed. These rules mirror this repo's hooks/;"
+            note "  installing them (see README) catches this locally before CI."
+          else
+            note "✓ policy gate passed."
+          fi
+          exit "$fail"

--- a/README.md
+++ b/README.md
@@ -61,3 +61,34 @@ Client-side hooks are bypassable (`--no-verify`) and only run if installed. The
 **authoritative** enforcement is server-side: GitHub branch protection + a CI
 check mirroring these same rules. Treat these hooks as fast local feedback that
 catches mistakes before they reach CI — not as the boundary itself.
+
+## CI policy gate (the server-side half)
+
+`.github/workflows/policy-gate.yml` is a **reusable workflow** that re-runs the
+same three rules on every PR — branch-name prefix, `<TICKET> #comment <msg>`
+commit subjects, and the secret-file/secret-content denylist. It reads the PR's
+own commits (`base..head`) and diff, so it sees exactly what the local hooks
+would have seen before a squash/merge. Plain bash, no secrets, `contents: read`
+only. It lives here, next to `hooks/`, so the two halves of the policy never
+drift — change a rule in `hooks/` and change it here in the same PR.
+
+**Add it to a repo** — commit this caller to the repo's default branch as
+`.github/workflows/policy-gate.yml`:
+
+```yaml
+name: Policy gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  policy-gate:                       # keep this job id — the required check is
+    uses: hooloovoodoo/git-hooks/.github/workflows/policy-gate.yml@master
+```
+
+git-hooks is public, so any org repo (private or public) can call it with no
+extra Actions access setup. Then, once a PR has run it once, add the
+**`policy-gate / check`** context to the branch's required status checks
+(Settings → Branches). Require it only *after* the caller is on the default
+branch — a required check that has never reported blocks every PR.
+
+`policy-gate-self.yml` dogfoods the gate on git-hooks' own PRs.


### PR DESCRIPTION
## What

The server-side half of the git-hooks policy (LET-3080), now living **in this repo** next to the hooks it mirrors — so the local and CI halves stay in one place and never drift. (Supersedes the earlier attempt to host this in falcon-agm; that one is being reverted.)

`.github/workflows/policy-gate.yml` is a **reusable workflow**. Each repo adds a thin caller; on every PR it re-checks the same three rules the client-side hooks enforce:

| Rule | Mirrors |
|---|---|
| PR branch starts with `feature/ bugfix/ release/ hotfix/ docs/ chore/ archive/` | `hooks/pre-push` |
| every non-merge commit subject is `<TICKET> #comment <msg>` (Merge/Revert/fixup!/squash! exempt; `falcon-doc(s)` exempt) | `hooks/commit-msg` |
| no `.env`/`.pgpass`/`*.pem`/`*.key`/ssh/aws secret files, no `BEGIN … PRIVATE KEY` / `AKIA…` content in the diff | `hooks/pre-commit` |

Checks the PR's own commits (`base..head`) and diff.

## Why git-hooks (not falcon-agm)

- The rules live here; the CI mirror belongs next to them.
- git-hooks is **public** → any org repo (private or public) can call it with zero Actions-access config, and it removes the public→private reusable-workflow problem entirely.

## Notes

- Plain bash. No secrets, no Claude token, no API spend. `contents: read` only.
- `policy-gate-self.yml` dogfoods it here (this PR runs `policy-gate / check`).
- Email check (`*@hooloovoo.rs`) from `pre-commit` intentionally **not** enforced (out of LET-3080 scope; noisy vs bot/web-flow authors).

## Validation

38/38 unit cases; real PR (doc-ingestion #299) range → pass; planted `.env` + `*.pem` + `AKIA…` + `PRIVATE KEY` via `--no-verify` → fail with exact findings; bad branch → fail. Confirmed live: the check reports as **`policy-gate / check`**, ~7s.

## Rollout (separate, paused pending review)

After merge: add the thin caller to each target repo's default branch (`uses: hooloovoodoo/git-hooks/.github/workflows/policy-gate.yml@master`), confirm `policy-gate / check` reports, then add it to required status checks.

## Side-finding

`hooks/commit-msg` exempts a repo named `falcon-docs`, but the live docs repo is **`falcon-doc`** (no "s") — that exemption matches nothing today. This gate exempts both spellings; the hook should be fixed separately.
