### PR TITLE
LET-3187 fix docs-repo commit-msg exemption (falcon-doc, was falcon-docs)

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -10,8 +10,9 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "$DIR/lib.sh"
 
-# falcon-docs is a docs-only repo — exempt from the ticket/#comment convention.
-if is_org_repo && [ "$(remote_repo)" = "falcon-docs" ]; then
+# The docs-only repo is exempt from the ticket/#comment convention. Its actual
+# name is falcon-doc; match falcon-docs too so a rename can't silently re-break this.
+if is_org_repo && [[ "$(remote_repo)" =~ ^falcon-docs?$ ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
## What

Fix the docs-repo exemption in `hooks/commit-msg` so it actually fires. Resolves LET-3187.

## Bug

Line 14 exempted the docs repo by comparing `remote_repo` to `falcon-docs`, but the repo is **`falcon-doc`** (singular). The names never matched, so the ticket/`#comment` rule was wrongly enforced on the docs repo (which CLAUDE.md documents as exempt), and every docs commit failed unless committed with `--no-verify`.

## Fix

Match both spellings so a future rename can't silently re-break it:

```bash
if is_org_repo && [[ "$(remote_repo)" =~ ^falcon-docs?$ ]]; then
```

## Verified

| Repo / input | Result |
|---|---|
| `falcon-doc`, non-ticket msg | exempt (exit 0) |
| `falcon-docs`, non-ticket msg | exempt (exit 0) |
| `doc-store`, non-ticket msg | rejected (exit 1) |
| `bash -n hooks/commit-msg` | clean |

## Rollout note

Machines run the hook from the installed **release** (`install.sh` pulls the latest release, not `master`), so this reaches devs only after a new tag + reinstall. Ties into LET-3073. Two CLAUDE.md cards repeat the wrong `falcon-docs` name; separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
