### PR TITLE
LET-3189 fix install.sh cleanup (no stray extracted dir on update)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,8 +43,11 @@ if [ ! -f "${LOCAL_HOOKS_VERSION_FILE}" ] || [ "${LATEST_VERSION}" != "$(cat "${
   curl -sL "${REPO_URL}/archive/refs/tags/${LATEST_VERSION}.zip" -o "${HOOKS_DIR}/hooks.zip"
   unzip -o "${HOOKS_DIR}/hooks.zip" -d "${HOOKS_DIR}"
   mv "${HOOKS_DIR}"/git-hooks-*/hooks/* "${HOOKS_DIR}"
-  for f in "${HOOKS_DIR}"/hooks.zip "${HOOKS_DIR}"/git-hooks-*/{README.md,install.sh}; do rm "${f}"; done
-  rmdir "${HOOKS_DIR}"/git-hooks-*/hooks "${HOOKS_DIR}"/git-hooks-*
+  rm -f "${HOOKS_DIR}"/hooks.zip
+  # Remove the whole extracted tree (hooks/ already moved out). rm -rf, not a
+  # selective rmdir, so a new top-level entry in the zip (e.g. .github/) can't
+  # leave a stray dir behind. HOOKS_DIR is fixed above, glob only matches the extract.
+  rm -rf "${HOOKS_DIR}"/git-hooks-*
   chmod +x "${HOOKS_DIR}"/* 2>/dev/null || true   # ensure hooks stay executable
   echo "${LATEST_VERSION}" > "${LOCAL_HOOKS_VERSION_FILE}"
   echo "Git hooks updated to version ${LATEST_VERSION}."


### PR DESCRIPTION
## What

Fix `install.sh` so updating leaves no stray extracted directory. Resolves LET-3189.

## Bug

The cleanup moved `hooks/*` up, removed `README.md` + `install.sh`, then `rmdir`'d the extract. That `rmdir` fails as soon as the release zip has any other top-level entry. v0.2.0 added `.github/workflows/`, so on every update `rmdir` errored with `Directory not empty` and left `~/.git-hooks/git-hooks-<ver>/` behind (seen updating to v0.2.1). Cosmetic (hooks install fine) but it reads as a failure, and it hits every dev in the LET-3073 rollout.

## Fix

```bash
mv "${HOOKS_DIR}"/git-hooks-*/hooks/* "${HOOKS_DIR}"
rm -f "${HOOKS_DIR}"/hooks.zip
rm -rf "${HOOKS_DIR}"/git-hooks-*
```

Move hooks out, then `rm -rf` the whole extracted tree instead of a selective `rmdir`. Robust to future top-level additions. `HOOKS_DIR` is fixed earlier in the script and the glob only matches the extract.

## Verified

- `bash -n install.sh` clean.
- Simulated an extract containing `.github/`: hooks move up to the root, no `git-hooks-*` dir left behind.

## Note

Ships in the next release. After merge I'll cut **v0.2.2** so the rollout picks up both this and the v0.2.1 exemption fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
